### PR TITLE
Update error handling to accept neo4j v3+ errors

### DIFF
--- a/neoutils/batch_cypher_runner.go
+++ b/neoutils/batch_cypher_runner.go
@@ -86,7 +86,7 @@ func processCypherBatch(bcr *BatchCypherRunner, currentQueries []*neoism.CypherQ
 			}
 
 			for _, nerr := range neoErrMsg.Errors {
-				if nerr.Code == "Neo.ClientError.Schema.ConstraintViolation" {
+				if nerr.Code == "Neo.ClientError.Schema.ConstraintViolation" || nerr.Code == "Neo.ClientError.Schema.ConstraintValidationFailed" {
 					return rwapi.ConstraintOrTransactionError{Message: nerr.Message}
 				}
 			}


### PR DESCRIPTION
From Neo4j version 3+ "ConstraintViolation" error is replaced by "ConstraintValidationFailed"